### PR TITLE
Update PartInfo.cfg

### DIFF
--- a/GameData/PartInfo/PartInfo.cfg
+++ b/GameData/PartInfo/PartInfo.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[~name[TCAModule*],~name[Deployed*]]:FINAL
+@PART[*]:HAS[~name[TCAModule*],~name[Deployed*],~name[Potato*]]:FINAL
 {
 	MODULE
 	{


### PR DESCRIPTION
ignore asteroids and comets.

Empty "Part Information" and nullref spam on asteroids in flight